### PR TITLE
Add support for CCTweaks plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ out
 *.iws
 *.iml
 .idea
+classes
 
 # gradle
 build

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
 
     shade 'org.eclipse.jgit:org.eclipse.jgit:4.5.0.201609210915-r'
 
-    compile "org.squiddev:CCTweaks:1.8.9-1.2.3:dev"
+    compile "org.squiddev:CCTweaks:1.8.9-1.3.0-pr0:dev"
 
     // real examples
     //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
 
     shade 'org.eclipse.jgit:org.eclipse.jgit:4.5.0.201609210915-r'
 
-    compile "org.squiddev:CCTweaks:1.8.9-1.3.0:dev"
+    compile "org.squiddev:CCTweaks:1.8.9-1.4.0:dev"
 
     // real examples
     //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 */
 version = "1.0"
 group= "com.yourname.modid" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = "modid"
+archivesBaseName = "ccgit"
 
 minecraft {
     version = "1.8.9-11.15.1.1902-1.8.9"
@@ -69,7 +69,7 @@ dependencies {
 
     shade 'org.eclipse.jgit:org.eclipse.jgit:4.5.0.201609210915-r'
 
-    compile "org.squiddev:CCTweaks:1.8.9-1.3.0-pr0:dev"
+    compile "org.squiddev:CCTweaks:1.8.9-1.3.0:dev"
 
     // real examples
     //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env

--- a/src/main/java/org/kingofgamesyami/ccgit/CCGit.java
+++ b/src/main/java/org/kingofgamesyami/ccgit/CCGit.java
@@ -1,10 +1,8 @@
 package org.kingofgamesyami.ccgit;
 
-import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.api.lua.ILuaContext;
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.peripheral.IComputerAccess;
-import net.minecraft.server.MinecraftServer;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.GitCommand;
 import org.eclipse.jgit.api.InitCommand;
@@ -15,6 +13,7 @@ import org.eclipse.jgit.lib.RepositoryBuilder;
 import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.transport.*;
+import org.squiddev.cctweaks.api.lua.IExtendedComputerAccess;
 import org.squiddev.cctweaks.api.lua.ILuaAPI;
 import org.squiddev.cctweaks.api.lua.IMethodDescriptor;
 
@@ -30,9 +29,9 @@ public class CCGit implements ILuaAPI, IMethodDescriptor {
     private int identifier = 0;
     private UsernamePasswordCredentialsProvider credentials;
 
-    public CCGit( IComputerAccess computer ){
+    public CCGit( IExtendedComputerAccess computer ){
         this.computer = computer;
-        this.computerDir = new File( ComputerCraft.getWorldDir( MinecraftServer.getServer().getEntityWorld() ), "computer/" + computer.getID() );
+        this.computerDir = computer.getRootMountPath();
     }
 
     @Override

--- a/src/main/java/org/kingofgamesyami/ccgit/CCGit.java
+++ b/src/main/java/org/kingofgamesyami/ccgit/CCGit.java
@@ -30,7 +30,7 @@ public class CCGit implements ILuaAPI, IMethodDescriptor {
     private int identifier = 0;
     private UsernamePasswordCredentialsProvider credentials;
 
-    public CCGit( IComputerAccess computer ){
+    public CCGit( IComputerAccess computer, String baseDir ){
         this.computer = computer;
         this.computerDir = new File( ComputerCraft.getWorldDir( MinecraftServer.getServer().getEntityWorld() ), "computer/" + computer.getID() );
     }
@@ -173,7 +173,7 @@ public class CCGit implements ILuaAPI, IMethodDescriptor {
 
     private Object[] sendToGitThread( ILuaContext context, GitCommand command ) throws LuaException, InterruptedException {
         int thisRequest = identifier++;
-        Main.gitRunnable.queue( new GitRequest( computer, thisRequest, command ) );
+        GitRunnable.instance.queue( new GitRequest( computer, thisRequest, command ) );
         while(true){
             Object[] event = context.pullEvent( "ccgit" );
             if( event.length > 2 && event[1] instanceof Double && (Double)event[ 1 ] == thisRequest ){
@@ -184,7 +184,7 @@ public class CCGit implements ILuaAPI, IMethodDescriptor {
 
     private Object[] sendToGitThread( ILuaContext context, InitCommand command ) throws LuaException, InterruptedException {
         int thisRequest = identifier++;
-        Main.gitRunnable.queue( new GitRequest( computer, thisRequest, command ) );
+        GitRunnable.instance.queue( new GitRequest( computer, thisRequest, command ) );
         while(true){
             Object[] event = context.pullEvent( "ccgit" );
             if( event.length > 2 && event[1] instanceof Double && (Double)event[ 1 ] == thisRequest ){

--- a/src/main/java/org/kingofgamesyami/ccgit/CCGit.java
+++ b/src/main/java/org/kingofgamesyami/ccgit/CCGit.java
@@ -30,7 +30,7 @@ public class CCGit implements ILuaAPI, IMethodDescriptor {
     private int identifier = 0;
     private UsernamePasswordCredentialsProvider credentials;
 
-    public CCGit( IComputerAccess computer, String baseDir ){
+    public CCGit( IComputerAccess computer ){
         this.computer = computer;
         this.computerDir = new File( ComputerCraft.getWorldDir( MinecraftServer.getServer().getEntityWorld() ), "computer/" + computer.getID() );
     }

--- a/src/main/java/org/kingofgamesyami/ccgit/LogHandler.java
+++ b/src/main/java/org/kingofgamesyami/ccgit/LogHandler.java
@@ -1,0 +1,55 @@
+package org.kingofgamesyami.ccgit;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Shared logger implementation
+ */
+public interface LogHandler {
+    /**
+     * Print an info message to the console
+     *
+     * @param message The message to print
+     */
+    void info(String message);
+
+    /**
+     * Print a warning message to the console
+     *
+     * @param message The message to print
+     */
+    void warning(String message);
+
+    /**
+     * Logger which runs under Minecraft, using the logger provided by {@link LogManager}.
+     */
+    class FMLLogger implements LogHandler {
+        private final Logger logger = LogManager.getLogger("CCGit");
+
+        @Override
+        public void info(String message) {
+            logger.info(message);
+        }
+
+        @Override
+        public void warning(String message) {
+            logger.warn(message);
+        }
+    }
+
+    /**
+     * Logger which runs in a environment without Minecraft (such as an emulator).
+     */
+    class BasicLogger implements LogHandler {
+        @Override
+        public void info(String message) {
+            System.out.println("[INFO] [CCGit] " + message);
+        }
+
+        @Override
+        public void warning(String message) {
+            System.out.println("[WARN] [CCGit] " + message);
+        }
+    }
+}

--- a/src/main/java/org/kingofgamesyami/ccgit/Main.java
+++ b/src/main/java/org/kingofgamesyami/ccgit/Main.java
@@ -7,6 +7,9 @@ import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartedEvent;
 import net.minecraftforge.fml.common.event.FMLServerStoppedEvent;
 import net.minecraftforge.fml.relauncher.Side;
+import org.squiddev.cctweaks.api.CCTweaksAPI;
+import org.squiddev.cctweaks.api.lua.CCTweaksPlugin;
+import org.squiddev.cctweaks.api.lua.ILuaEnvironment;
 
 /**
  * Created by Steven on 11/25/2016.
@@ -19,7 +22,7 @@ public class Main {
     @Mod.EventHandler
     public void init(FMLInitializationEvent event)
     {
-        Register.init();
+        Register.init(CCTweaksAPI.instance().luaEnvironment());
         gitRunnable = new GitRunnable();
         gitRunnable.setName( "Git Thread" );
     }
@@ -37,6 +40,17 @@ public class Main {
         if (FMLCommonHandler.instance().getEffectiveSide() == Side.SERVER) {
             FMLLog.info( "Stopping Git Thread" );
             gitRunnable.interrupt();
+        }
+    }
+
+    public static class CCGitPlugin extends CCTweaksPlugin {
+        @Override
+        public void register(ILuaEnvironment environment) {
+            Register.init(environment);
+            gitRunnable = new GitRunnable();
+            gitRunnable.setDaemon(true);
+            gitRunnable.setName( "Git Thread" );
+            gitRunnable.start();
         }
     }
 }

--- a/src/main/java/org/kingofgamesyami/ccgit/Main.java
+++ b/src/main/java/org/kingofgamesyami/ccgit/Main.java
@@ -1,7 +1,6 @@
 package org.kingofgamesyami.ccgit;
 
 import net.minecraftforge.fml.common.FMLCommonHandler;
-import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartedEvent;
@@ -16,30 +15,28 @@ import org.squiddev.cctweaks.api.lua.ILuaEnvironment;
  */
 @Mod( modid="ccgit", version = "0.1")
 public class Main {
-
-    public static GitRunnable gitRunnable;
+    private final LogHandler logger = new LogHandler.FMLLogger();
 
     @Mod.EventHandler
     public void init(FMLInitializationEvent event)
     {
         Register.init(CCTweaksAPI.instance().luaEnvironment());
-        gitRunnable = new GitRunnable();
-        gitRunnable.setName( "Git Thread" );
+        GitRunnable.instance = new GitRunnable( logger );
     }
 
     @Mod.EventHandler
     public void onServerStart(FMLServerStartedEvent event) {
         if (FMLCommonHandler.instance().getEffectiveSide() == Side.SERVER) {
-            FMLLog.info( "Attempting to start Git Thread" );
-            gitRunnable.start();
+            logger.info( "Attempting to start Git Thread" );
+            GitRunnable.instance.start();
         }
     }
 
     @Mod.EventHandler
     public void onServerStopped(FMLServerStoppedEvent event) {
         if (FMLCommonHandler.instance().getEffectiveSide() == Side.SERVER) {
-            FMLLog.info( "Stopping Git Thread" );
-            gitRunnable.interrupt();
+            logger.info( "Stopping Git Thread" );
+            GitRunnable.instance.interrupt();
         }
     }
 
@@ -47,10 +44,8 @@ public class Main {
         @Override
         public void register(ILuaEnvironment environment) {
             Register.init(environment);
-            gitRunnable = new GitRunnable();
-            gitRunnable.setDaemon(true);
-            gitRunnable.setName( "Git Thread" );
-            gitRunnable.start();
+            GitRunnable.instance = new GitRunnable( new LogHandler.BasicLogger() );
+            GitRunnable.instance.start();
         }
     }
 }

--- a/src/main/java/org/kingofgamesyami/ccgit/Register.java
+++ b/src/main/java/org/kingofgamesyami/ccgit/Register.java
@@ -1,10 +1,11 @@
 package org.kingofgamesyami.ccgit;
 
-import dan200.computercraft.api.peripheral.IComputerAccess;
-import org.squiddev.cctweaks.api.CCTweaksAPI;
+import org.squiddev.cctweaks.api.lua.IExtendedComputerAccess;
 import org.squiddev.cctweaks.api.lua.ILuaAPI;
 import org.squiddev.cctweaks.api.lua.ILuaAPIFactory;
 import org.squiddev.cctweaks.api.lua.ILuaEnvironment;
+
+import javax.annotation.Nonnull;
 
 /**
  * Created by Steven on 11/25/2016.
@@ -13,10 +14,11 @@ public class Register {
     public static void init(ILuaEnvironment environment) {
         environment.registerAPI(new ILuaAPIFactory() {
             @Override
-            public ILuaAPI create(IComputerAccess computer) {
+            public ILuaAPI create(@Nonnull IExtendedComputerAccess computer) {
                 return new CCGit( computer );
             }
 
+            @Nonnull
             @Override
             public String[] getNames() {
                 return new String[]{"ccgit"};

--- a/src/main/java/org/kingofgamesyami/ccgit/Register.java
+++ b/src/main/java/org/kingofgamesyami/ccgit/Register.java
@@ -10,9 +10,7 @@ import org.squiddev.cctweaks.api.lua.ILuaEnvironment;
  * Created by Steven on 11/25/2016.
  */
 public class Register {
-    public static void init() {
-        ILuaEnvironment environment = CCTweaksAPI.instance().luaEnvironment();
-
+    public static void init(ILuaEnvironment environment) {
         environment.registerAPI(new ILuaAPIFactory() {
             @Override
             public ILuaAPI create(IComputerAccess computer) {

--- a/src/main/resources/META-INF/services/org.squiddev.cctweaks.api.lua.CCTweaksPlugin
+++ b/src/main/resources/META-INF/services/org.squiddev.cctweaks.api.lua.CCTweaksPlugin
@@ -1,0 +1,1 @@
+org.kingofgamesyami.ccgit.Main$CCGitPlugin


### PR DESCRIPTION
This adds support for loading through CCTweaks' plugin system for emulators.

It currently loads fine, but does not run as it depends on `FMLLog`. I'm just opening this issue to:
- Show a proof of concept.
- Ask your opinion on moving logging to a platform independent class. CCTweaks provides a `Logger` class, but you probably don't want/shouldn't use that as it is internal.
- Ask about moving the construction of `gitRunnable` to somewhere else.